### PR TITLE
D10 compatible version of the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Includes:
 
 Require package:
 
-```composer require guncha25/drupal-codeception --dev```
+```composer require wunderio/drupal-codeception --dev```
 
 If codeception was not previously set up:
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "composer/installers": "^2",
-    "drupal/core": "^9 || ^10"
+    "drupal/core": "^10"
   },
   "license": "GPL-2.0",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     }
   ],
   "require": {
-    "codeception/codeception": "^4.2",
-    "codeception/module-webdriver": "^2.0",
+    "codeception/codeception": "^5",
+    "codeception/module-webdriver": "^4",
     "webflo/drupal-finder": "^1.2",
     "fakerphp/faker": "^1.19"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,39 @@
 {
-    "name": "wunderio/drupal-codeception",
-    "description": "Codeception toolset for Drupal testing.",
-    "type": "package",
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://packages.drupal.org/8"
-        }
-    ],
-    "require": {
-        "codeception/codeception": "^4.2",
-        "codeception/module-webdriver": "^2.0",
-        "webflo/drupal-finder": "^1.2",
-        "fakerphp/faker": "^1.19"
-    },
-    "require-dev": {
-        "composer/installers": "^2",
-        "drupal/core": "^9"
-    },
-    "license": "GPL-2.0",
-    "authors": [
-        {
-            "name": "Guntis Jakovins",
-            "email": "guntis.jakovins@gmail.com"
-        }
-    ],
-    "minimum-stability": "stable",
-    "autoload": {
-        "psr-4": {
-            "Codeception\\": "src/Codeception"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/installers": true
-        }
+  "name": "wunderio/drupal-codeception",
+  "description": "Codeception toolset for Drupal testing.",
+  "type": "package",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
     }
+  ],
+  "require": {
+    "codeception/codeception": "^4.2",
+    "codeception/module-webdriver": "^2.0",
+    "webflo/drupal-finder": "^1.2",
+    "fakerphp/faker": "^1.19"
+  },
+  "require-dev": {
+    "composer/installers": "^2",
+    "drupal/core": "^9 || ^10"
+  },
+  "license": "GPL-2.0",
+  "authors": [
+    {
+      "name": "Guntis Jakovins",
+      "email": "guntis.jakovins@gmail.com"
+    }
+  ],
+  "minimum-stability": "stable",
+  "autoload": {
+    "psr-4": {
+      "Codeception\\": "src/Codeception"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "codeception/codeception": "^5",
-    "codeception/module-webdriver": "^4",
+    "codeception/module-webdriver": "^3",
     "webflo/drupal-finder": "^1.2",
     "fakerphp/faker": "^1.19"
   },

--- a/src/Codeception/Module/DrupalBootstrap.php
+++ b/src/Codeception/Module/DrupalBootstrap.php
@@ -30,7 +30,7 @@ class DrupalBootstrap extends Module {
    *
    * @var array
    */
-  protected $config = [
+  protected array $config = [
     'site_path' => 'sites/default',
   ];
 

--- a/src/Codeception/Module/DrupalDrush.php
+++ b/src/Codeception/Module/DrupalDrush.php
@@ -28,7 +28,7 @@ class DrupalDrush extends Module {
    *
    * @var array
    */
-  protected $config = [
+  protected array $config = [
     'drush' => 'drush',
     'alias' => '',
     'options' => [],

--- a/src/Codeception/Module/DrupalEntity.php
+++ b/src/Codeception/Module/DrupalEntity.php
@@ -5,7 +5,7 @@ namespace Codeception\Module;
 use Codeception\Module;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Url;
-use Codeception\TestCase;
+use Codeception\TestInterface;
 
 /**
  * Class DrupalEntity.
@@ -30,7 +30,7 @@ class DrupalEntity extends Module {
    *
    * @var array
    */
-  protected $config = [
+  protected array $config = [
     'cleanup_test' => TRUE,
     'cleanup_failed' => TRUE,
     'cleanup_suite' => TRUE,
@@ -60,7 +60,7 @@ class DrupalEntity extends Module {
   /**
    * {@inheritdoc}
    */
-  public function _after(TestCase $test) { // @codingStandardsIgnoreLine
+  public function _after(TestInterface $test) { // @codingStandardsIgnoreLine
     if ($this->config['cleanup_test']) {
       $this->doEntityCleanup();
     }
@@ -69,7 +69,7 @@ class DrupalEntity extends Module {
   /**
    * {@inheritdoc}
    */
-  public function _failed(TestCase $test, $fail) { // @codingStandardsIgnoreLine
+  public function _failed(TestInterface $test, $fail) { // @codingStandardsIgnoreLine
     if ($this->config['cleanup_failed']) {
       $this->doEntityCleanup();
     }

--- a/src/Codeception/Module/DrupalUser.php
+++ b/src/Codeception/Module/DrupalUser.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\user\Entity\User;
 use Faker\Factory;
 use Codeception\Util\Drush;
+use Codeception\TestInterface;
 
 /**
  * Class DrupalUser.
@@ -51,7 +52,7 @@ class DrupalUser extends Module {
    *
    * @var array
    */
-  protected $config = [
+  protected array $config = [
     'alias' => '',
     'default_role' => 'authenticated',
     'driver' => 'WebDriver',
@@ -77,7 +78,7 @@ class DrupalUser extends Module {
   /**
    * {@inheritdoc}
    */
-  public function _after(\Codeception\TestCase $test) { // @codingStandardsIgnoreLine
+  public function _after(TestInterface $test) { // @codingStandardsIgnoreLine
     if ($this->_getConfig('cleanup_test')) {
       $this->userCleanup();
     }
@@ -86,7 +87,7 @@ class DrupalUser extends Module {
   /**
    * {@inheritdoc}
    */
-  public function _failed(\Codeception\TestCase $test, $fail) { // @codingStandardsIgnoreLine
+  public function _failed(TestInterface $test, $fail) { // @codingStandardsIgnoreLine
     if ($this->_getConfig('cleanup_failed')) {
       $this->userCleanup();
     }

--- a/src/Codeception/Module/DrupalWatchdog.php
+++ b/src/Codeception/Module/DrupalWatchdog.php
@@ -35,7 +35,7 @@ class DrupalWatchdog extends Module {
    *
    * @var array
    */
-  protected $config = [
+  protected array $config = [
     'channels' => [],
     'level' => 'ERROR',
     'enabled' => TRUE,

--- a/src/Codeception/TestDrupalKernel.php
+++ b/src/Codeception/TestDrupalKernel.php
@@ -4,7 +4,7 @@ namespace Codeception;
 
 use Drupal\Core\DrupalKernel;
 use Drupal\Core\Site\Settings;
-use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+use Drupal\Core\Routing\RouteObjectInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 


### PR DESCRIPTION
> ATTENTION! The changes in this branch mean that the package will not work with drupal9.

This PR is against the new 10.x branch.



This branch adds Drupal 10 support to the package, by

* upgrading to codeception5 (because only this version supports symfony 6 which drupal10 uses
* upgrading to module-webdriver 3 (this still supports phpunit9, version 4 requires phpunit10)
* adding small fixes to the existing integration code to make d10 happy (details in comments)

## To test

1.  add this repository to your project's composer.json `repositories` section:

```
  {
            "type": "vcs",
            "url": "https://github.com/vermario/drupal-codeception"
        },
``` 

2. `composer require wunderio/drupal-codeception:10.x --dev`


The tests should run as usual. 


I have not tried this with drupal9, but in theory it should work there as well. Could you help testing it on drupal 9? 

if it works, then maybe we can merge this over the 9.x branch? or how do we create a new version in composer?
